### PR TITLE
[codex] Establish AI microservices lab baseline

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,20 +1,29 @@
 # GitHub Actions Workflows
 
-This page describes the CI/CD workflows for the Online Boutique app, which run in [Github Actions](https://github.com/GoogleCloudPlatform/microservices-demo/actions).
+This page describes the CI/CD workflows for `however-microservices-lab`.
 
 ## Infrastructure
 
-The CI/CD pipelines for Online Boutique run in Github Actions, using a pool of two [self-hosted runners]((https://help.github.com/en/actions/automating-your-workflow-with-github-actions/about-self-hosted-runners)). These runners are GCE instances (virtual machines) that, for every open Pull Request in the repo, run the code test pipeline, deploy test pipeline, and (on main) deploy the latest version of the app to [cymbal-shops.retail.cymbal.dev](https://cymbal-shops.retail.cymbal.dev)
+The default quality gate is [quick-ci.yaml](quick-ci.yaml), which runs on `ubuntu-latest` and does not require self-hosted runners.
 
-We also host a test GKE cluster, which is where the deploy tests run. Every PR has its own namespace in the cluster.
+The legacy PR/Main deployment workflows are still present for GKE staging scenarios that need Google Cloud credentials and self-hosted runner capacity. They should be treated as optional release/deployment infrastructure, not as the baseline contributor CI.
 
 ## Workflows
 
-**Note**: In order for the current CI/CD setup to work on your pull request, you must branch directly off the repo (no forks). This is because the Github secrets necessary for these tests aren't copied over when you fork.
+**Note**: `quick-ci.yaml` works for ordinary pull requests. Legacy deploy workflows that stage into GKE still require repository secrets and trusted runner access.
+
+### Quick Multi-Language CI - [quick-ci.yaml](quick-ci.yaml)
+
+Runs on `ubuntu-latest` for pull requests, pushes to `main`, and manual dispatch. It covers:
+
+1. Go unit tests for `frontend`, `productcatalogservice`, `shippingservice` and `checkoutservice`.
+2. Node.js tests for `currencyservice` and `paymentservice`.
+3. Python ruff/mypy/pytest for `shoppingassistantservice`.
+4. Java Gradle tests and PMD for `adservice`.
 
 ### Code Tests - [ci-pr.yaml](ci-pr.yaml)
 
-These tests run on every commit for every open PR, as well as any commit to main / any release branch. Currently, this workflow runs only Go unit tests.
+These legacy tests run on self-hosted runners and are kept for cloud staging compatibility.
 
 
 ### Deploy Tests- [ci-pr.yaml](ci-pr.yaml)
@@ -27,20 +36,15 @@ These tests run on every commit for every open PR, as well as any commit to main
 4. Gets the LoadBalancer IP for the frontend service.
 5. Comments that IP in the pull request, for staging.
 
-### Push and Deploy Latest - [push-deploy](push-deploy.yml)
+### Push and Deploy Latest - legacy upstream reference
 
-This is the Continuous Deployment workflow, and it runs on every commit to the main branch. This workflow:
-
-1. Builds the container images for every service, tagging as `latest`.
-2. Pushes those images to Google Container Registry.
-
-Note that this workflow does not update the image tags used in `release/kubernetes-manifests.yaml` - these release manifests are tied to a stable `v0.x.x` release.
+The original upstream project included a push-and-deploy workflow for publishing `latest` images. In however-microservices-lab, production publishing should be treated as a release-specific decision rather than the default contributor path.
 
 ### Cleanup - [cleanup.yaml](cleanup.yaml)
 
 This workflow runs when a PR closes, regardless of whether it was merged into main. This workflow deletes the PR-specific GKE namespace in the test cluster.
 
-## Appendix - Creating a new Actions runner
+## Appendix - Legacy self-hosted runners
 
 Should one of the two self-hosted Github Actions runners (GCE instances) fail, or you want to add more runner capacity, this is how to provision a new runner. Note that you need IAM access to the admin Online Boutique GCP project in order to do this.
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -21,14 +21,14 @@ Runs on `ubuntu-latest` for pull requests, pushes to `main`, and manual dispatch
 3. Python ruff/mypy/pytest for `shoppingassistantservice`.
 4. Java Gradle tests and PMD for `adservice`.
 
-### Code Tests - [ci-pr.yaml](ci-pr.yaml)
+### Legacy GKE PR Staging - [ci-pr.yaml](ci-pr.yaml)
 
-These legacy tests run on self-hosted runners and are kept for cloud staging compatibility.
+This workflow is manual-only. It still uses self-hosted runners and the historical GKE staging cluster, so it is kept for cloud staging compatibility rather than baseline PR quality gates.
 
 
-### Deploy Tests- [ci-pr.yaml](ci-pr.yaml)
+### Deploy Tests - [ci-pr.yaml](ci-pr.yaml)
 
-These tests run on every commit for every open PR, as well as any commit to main / any release branch. This workflow:
+These tests run only through `workflow_dispatch`. This workflow:
 
 1. Creates a dedicated GKE namespace for that PR, if it doesn't already exist, in the PR GKE cluster.
 2. Uses `skaffold run` to build and push the images specific to that PR commit. Then skaffold deploys those images, via `kubernetes-manifests`, to the PR namespace in the test cluster.

--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -55,8 +55,8 @@ jobs:
       run: |
         PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
         NAMESPACE="pr${PR_NUMBER}"
-        echo "::set-env name=NAMESPACE::$NAMESPACE"
-        echo "::set-env name=PR_NUMBER::$PR_NUMBER"
+        echo "NAMESPACE=${NAMESPACE}" >> "${GITHUB_ENV}"
+        echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
 
         yes | gcloud auth configure-docker us-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
@@ -70,7 +70,6 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=us-docker.pkg.dev/$PROJECT_ID/$GITHUB_REF --tag=$GITHUB_SHA --namespace=$NAMESPACE -p network-policies
       env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PROJECT_ID: "online-boutique-ci"
         PR_CLUSTER: "prs-gke-cluster"
         REGION: "us-central1"

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -73,7 +73,7 @@ jobs:
       timeout-minutes: 20
       run: |
         NAMESPACE="pr${PR_NUMBER}"
-        echo "::set-env name=NAMESPACE::$NAMESPACE"
+        echo "NAMESPACE=${NAMESPACE}" >> "${GITHUB_ENV}"
 
         yes | gcloud auth configure-docker us-docker.pkg.dev
         gcloud container clusters get-credentials $PR_CLUSTER --region $REGION --project $PROJECT_ID
@@ -87,7 +87,6 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=us-docker.pkg.dev/$PROJECT_ID/refs/pull/$PR_NUMBER --tag=$PR_NUMBER --namespace=$NAMESPACE -p network-policies
       env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
         PROJECT_ID: "online-boutique-ci"
         PR_CLUSTER: "prs-gke-cluster"
@@ -122,9 +121,8 @@ jobs:
         sleep 3
         done
         EXTERNAL_IP=$(get_externalIP)
-        echo "::set-env name=EXTERNAL_IP::$EXTERNAL_IP"
+        echo "EXTERNAL_IP=${EXTERNAL_IP}" >> "${GITHUB_ENV}"
       env:
-        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
         PR_NUMBER: ${{ github.event.pull_request.number }}
     - name: Smoke Test
       timeout-minutes: 5

--- a/.github/workflows/ci-pr.yaml
+++ b/.github/workflows/ci-pr.yaml
@@ -14,17 +14,16 @@
 
 name: "Continuous Integration - Pull Request"
 on:
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**/README.md'
-      - 'kustomize/**'
-      - '.github/workflows/kustomize-build-ci.yaml'
-      - 'terraform/**'
-      - '.github/workflows/terraform-validate-ci.yaml'
-      - 'helm-chart/**'
-      - '.github/workflows/helm-chart-ci.yaml'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number or manual namespace suffix for the legacy GKE staging run"
+        required: false
+        type: string
+      deploy_ref:
+        description: "Git ref/SHA to checkout for the legacy GKE staging run"
+        required: false
+        type: string
 
 # Ensure this workflow only runs for the most recent commit of a pull-request
 concurrency:
@@ -68,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v6
       with:
-        ref: ${{github.event.pull_request.head.sha}}
+        ref: ${{ inputs.deploy_ref || github.ref }}
     - name: Build + Deploy PR images to GKE
       timeout-minutes: 20
       run: |
@@ -87,7 +86,7 @@ jobs:
         skaffold config set --global local-cluster false
         skaffold run --default-repo=us-docker.pkg.dev/$PROJECT_ID/refs/pull/$PR_NUMBER --tag=$PR_NUMBER --namespace=$NAMESPACE -p network-policies
       env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ inputs.pr_number || github.run_number }}
         PROJECT_ID: "online-boutique-ci"
         PR_CLUSTER: "prs-gke-cluster"
         REGION: "us-central1"
@@ -123,7 +122,7 @@ jobs:
         EXTERNAL_IP=$(get_externalIP)
         echo "EXTERNAL_IP=${EXTERNAL_IP}" >> "${GITHUB_ENV}"
       env:
-        PR_NUMBER: ${{ github.event.pull_request.number }}
+        PR_NUMBER: ${{ inputs.pr_number || github.run_number }}
     - name: Smoke Test
       timeout-minutes: 5
       run: |

--- a/.github/workflows/quick-ci.yaml
+++ b/.github/workflows/quick-ci.yaml
@@ -1,0 +1,77 @@
+name: "Quick Multi-Language CI"
+
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  quick-ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26.1"
+          cache-dependency-path: |
+            src/frontend/go.sum
+            src/productcatalogservice/go.sum
+            src/shippingservice/go.sum
+            src/checkoutservice/go.sum
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: |
+            src/currencyservice/package-lock.json
+            src/paymentservice/package-lock.json
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: "pip"
+          cache-dependency-path: src/shoppingassistantservice/requirements.txt
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "21"
+
+      - name: Go unit tests
+        run: |
+          set -euo pipefail
+          for service in frontend productcatalogservice shippingservice checkoutservice; do
+            echo "==> go test ${service}"
+            (cd "src/${service}" && go test ./...)
+          done
+
+      - name: Node service tests
+        run: |
+          set -euo pipefail
+          for service in currencyservice paymentservice; do
+            echo "==> npm test ${service}"
+            (cd "src/${service}" && npm ci && npm test)
+          done
+
+      - name: Python shopping assistant checks
+        working-directory: src/shoppingassistantservice
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+          ruff check .
+          mypy shoppingassistantservice.py config.py metrics.py resilience.py retriever.py model_client.py
+          pytest
+
+      - name: Java adservice tests
+        working-directory: src/adservice
+        run: |
+          chmod +x gradlew
+          ./gradlew test pmdMain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2026-04-29
+- docs: add upstream diff proof for AI microservices lab positioning
+- docs: rewrite README first screen around AI assistant, local Ollama, Kubernetes and service matrix
+- feat(local-demo): add Redis + Ollama + JSON catalog demo entrypoint
+- ci: add ubuntu-latest quick multi-language CI and replace deprecated set-env usage
+- test(ai): cover Gemini/Ollama contracts, JSON fallback, healthz and degraded model responses
+- docs(release): draft AI microservices lab baseline release notes
+
 ## 2026-04-25
 - b32ff04 fix(ci): let changelog updates run checks
 - e282ff4 docs: auto update changelog [skip ci]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - docs: rewrite README first screen around AI assistant, local Ollama, Kubernetes and service matrix
 - feat(local-demo): add Redis + Ollama + JSON catalog demo entrypoint
 - ci: add ubuntu-latest quick multi-language CI and replace deprecated set-env usage
+- ci: make legacy self-hosted PR staging workflow manual-only
 - test(ai): cover Gemini/Ollama contracts, JSON fallback, healthz and degraded model responses
 - docs(release): draft AI microservices lab baseline release notes
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL := /bin/bash
 
-.PHONY: check-all check-java check-node check-python check-e2e
+.PHONY: check-all check-java check-node check-python check-e2e local-demo local-demo-stop local-demo-status
 
 check-all:
 	bash scripts/checks/run_all_checks.sh
@@ -20,3 +20,12 @@ check-python:
 
 check-e2e:
 	bash tests/e2e/kind_skaffold_smoke.sh
+
+local-demo:
+	bash scripts/local-demo.sh start
+
+local-demo-stop:
+	bash scripts/local-demo.sh stop
+
+local-demo-status:
+	bash scripts/local-demo.sh status

--- a/README.md
+++ b/README.md
@@ -1,23 +1,35 @@
-# however-microservices-lab - 微服务架构实践实验室 | Microservices Architecture Lab
+# however-microservices-lab
 
 <p align="center">
-  <img src="docs/img/however-logo.svg" width="360" alt="however logo" />
+  <img src="docs/img/however-logo.svg" width="340" alt="however logo" />
 </p>
 
-🔥 面向云原生工程实践的多语言微服务样例仓库。  
-🚀 聚焦配置解耦、可观测性、可替换 AI 推理后端（Gemini/Ollama）和本地化部署。  
-⭐ 适合作为微服务架构学习、二次开发与工程化改造基线。
+`however-microservices-lab` 是一个“云原生微服务 + AI 集成实验室”。它基于 Google Online Boutique 的多语言微服务样例继续改造，但核心目标已经从“电商 demo”升级为“可展示工程能力的微服务改造样板”：AI Shopping Assistant、本地 Ollama、JSON catalog fallback、Kubernetes 部署、多语言服务测试和 CI 基线都放在同一个仓库里。
 
 <p align="center">
-  <img src="https://img.shields.io/badge/Architecture-Microservices-0ea5e9" alt="Architecture" />
+  <img src="https://img.shields.io/badge/AI-Gemini%20%7C%20Ollama-0b66d7" alt="AI backends" />
   <img src="https://img.shields.io/badge/Runtime-Kubernetes-22c55e" alt="Kubernetes" />
   <img src="https://img.shields.io/badge/Protocols-gRPC%20%2B%20HTTP-f59e0b" alt="Protocols" />
-  <img src="https://img.shields.io/badge/AI%20Backend-Gemini%20%7C%20Ollama-64748b" alt="AI backend" />
+  <img src="https://img.shields.io/badge/Services-Go%20Python%20Node%20Java%20C%23-f59e0b" alt="languages" />
+  <img src="https://img.shields.io/badge/CI-ubuntu--latest-64748b" alt="quick ci" />
   <br/>
   <img src="https://github.com/however-yir/however-microservices-lab/actions/workflows/ci-main.yaml/badge.svg" alt="CI">
 </p>
 
----
+## 首屏重点
+
+| 能力 | 入口 | 说明 |
+|---|---|---|
+| AI Shopping Assistant | `src/shoppingassistantservice` + `/assistant` | Python Flask 助手服务接入 Go frontend，支持文本/图片输入、商品 ID 推荐、健康检查、指标、限流、熔断和降级 |
+| 本地 Ollama 演示 | `make local-demo` | 本地 Redis + Ollama + JSON 商品数据，快速验证 `MODEL_PROVIDER=ollama` 和 `VECTORSTORE_BACKEND=json` |
+| Kubernetes 部署 | `skaffold run` / `make check-e2e` | 原生 manifests、Kustomize components、kind smoke、Skaffold 构建部署 |
+| 多语言工程矩阵 | Go / Python / Node.js / Java / C# | 保留电商主链路，同时补 AI 服务、质量测试和 CI 现代化 |
+
+![however architecture](docs/img/however-architecture.svg)
+
+| Frontend | AI assistant |
+|---|---|
+| ![frontend screenshot](docs/img/frontend-screenshot.svg) | ![assistant screenshot](docs/img/assistant-screenshot.svg) |
 
 ## AI 工程作品矩阵
 
@@ -31,297 +43,168 @@
 | [`forgepilot-studio`](https://github.com/however-yir/forgepilot-studio) | AI 工程执行工作台 | AI 编程任务、执行编排、审计回放、团队工作台 | Python、FastAPI、React、Runtime Sandbox、MCP |
 | [`however-microservices-lab`](https://github.com/however-yir/however-microservices-lab) | 云原生微服务 + AI 集成实验室 | 多语言微服务、Kubernetes、gRPC、AI 服务接入 | Go、Python、Java、Node.js、C#、K8s、Ollama/Gemini |
 
-## 目录
+## 快速开始
 
-- [AI 工程作品矩阵](#ai-工程作品矩阵)
-- [1. 项目定位](#1-项目定位)
-- [2. 改造目标](#2-改造目标)
-- [3. 核心改动总览](#3-核心改动总览)
-- [4. 微服务清单](#4-微服务清单)
-- [5. 架构总览](#5-架构总览)
-- [6. 项目结构](#6-项目结构)
-- [7. 快速开始](#7-快速开始)
-- [8. 配置说明（数据库/Redis/Ollama）](#8-配置说明数据库redisollama)
-- [9. 部署方式](#9-部署方式)
-- [10. 与原版差异](#10-与原版差异)
-- [11. 仓库信息与协议](#11-仓库信息与协议)
-- [12. 质量检测与验证](#12-质量检测与验证)
-
----
-
-## 1. 项目定位
-
-本仓库用于演示“多语言微服务在真实工程中如何持续演进”，重点不在单次跑通，而在长期可维护：
-
-- 支持微服务之间通过 gRPC 协作，前端通过 HTTP 暴露业务入口。
-- 支持 Kubernetes/Skaffold/Kustomize 多种部署路径。
-- 支持 AI 助手服务按环境切换模型后端（Gemini 或 Ollama）。
-- 支持关键地址配置外置，降低硬编码和环境耦合风险。
-
----
-
-## 2. 改造目标
-
-1. 建立统一的项目命名与命名空间规范。  
-2. 将数据库、缓存、模型 API 地址全部参数化。  
-3. 在不破坏主链路的前提下，提升依赖与配置可维护性。  
-4. 对购物助手服务做结构化重构，支持扩展能力。  
-5. 输出完整中文文档，便于交接与二开。
-
----
-
-## 3. 核心改动总览
-
-### 3.1 命名空间与构建标识
-
-- `src/adservice` 已调整构建元信息：
-  - `group`: `com.however.microservices`
-  - `artifact`（通过 `settings.gradle`）：`however-adservice`
-- Java 包声明已迁移：
-  - `hipstershop.*` -> `com.however.microservices.adservice.*`
-
-### 3.2 配置外置与本地化
-
-- 新增 `configs/however.env.example`，统一管理本地化参数。
-- `shoppingassistantservice` 新增可配置项：
-  - `MODEL_PROVIDER=gemini|ollama`
-  - `OLLAMA_BASE_URL` / `OLLAMA_MODEL`
-  - `VECTORSTORE_BACKEND=alloydb|json`
-  - `ALLOYDB_USER` / `ALLOYDB_PASSWORD` / `ALLOYDB_SECRET_NAME`
-
-### 3.3 依赖与构建维护
-
-- Node 服务 `currencyservice`、`paymentservice` 更新了项目元信息（名称、仓库、License、Node 版本约束）。
-- Java `adservice` 启动脚本与 Docker 入口路径同步更新。
-
-### 3.4 代码重构与新功能
-
-`shoppingassistantservice` 已进行结构化拆分：
-
-- `AppConfig`：统一配置读取
-- `CatalogRetriever`：检索后端抽象（AlloyDB / JSON 回退）
-- `DesignModelClient`：模型后端抽象（Gemini / Ollama）
-- 新增 `GET /healthz`
-- 新增本地兜底商品文件：`src/shoppingassistantservice/products.local.json`
-
----
-
-## 4. 微服务清单
-
-| 服务 | 语言 | 职责 |
-|---|---|---|
-| `frontend` | Go | Web 入口与页面渲染 |
-| `cartservice` | C# | 购物车存储（Redis/替代后端） |
-| `productcatalogservice` | Go | 商品目录检索 |
-| `currencyservice` | Node.js | 汇率与货币转换 |
-| `paymentservice` | Node.js | 支付模拟 |
-| `shippingservice` | Go | 运费与配送模拟 |
-| `emailservice` | Python | 订单邮件模拟 |
-| `checkoutservice` | Go | 结算编排 |
-| `recommendationservice` | Python | 推荐服务 |
-| `adservice` | Java | 广告推荐服务 |
-| `shoppingassistantservice` | Python | 图片/文本购物助手（可切换模型） |
-| `loadgenerator` | Python | 压测流量生成 |
-
----
-
-## 5. 架构总览
-
-```mermaid
-flowchart LR
-  U[用户浏览器] --> F[frontend]
-  F --> C[checkoutservice]
-  F --> CART[cartservice]
-  F --> P[productcatalogservice]
-  F --> R[recommendationservice]
-  F --> A[adservice]
-  F --> SA[shoppingassistantservice]
-
-  C --> PAY[paymentservice]
-  C --> S[shippingservice]
-  C --> E[emailservice]
-
-  CART --> REDIS[(Redis)]
-  SA --> MODEL[Gemini / Ollama]
-  SA --> VDB[AlloyDB / JSON Catalog]
-```
-
----
-
-## 6. 项目结构
-
-```text
-.
-├── README.md
-├── LICENSE
-├── LICENSE-HOWEVER.md
-├── configs/
-│   └── however.env.example
-├── docs/
-│   └── img/however-logo.svg
-├── kustomize/
-│   └── components/
-│       ├── shopping-assistant/
-│       └── local-endpoints/
-└── src/
-    ├── adservice/
-    ├── shoppingassistantservice/
-    ├── frontend/
-    └── ...
-```
-
----
-
-## 7. 快速开始
-
-### 7.1 本地准备
-
-- Docker / Docker Compose
-- Kubernetes（可选）
-- `skaffold`（可选）
-
-### 7.2 一键安装与运行（推荐）
-
-- macOS（自动安装 Docker/kubectl/skaffold/kind，并执行部署）：
+### 1. 本地 AI 演示
 
 ```bash
-bash scripts/setup/quickstart-macos.sh
+make local-demo
+curl -sS http://127.0.0.1:18081/healthz
 ```
 
-- Windows PowerShell（自动安装 Docker/kubectl/skaffold/kind，并执行部署）：
-
-```powershell
-powershell -ExecutionPolicy Bypass -File .\scripts\setup\quickstart-windows.ps1
-```
-
-部署完成后可执行：
+需要真实 Ollama 推理时再拉模型：
 
 ```bash
-kubectl port-forward deployment/frontend 8080:8080
+LOCAL_DEMO_PULL_MODEL=1 make local-demo
+curl -sS \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Recommend warm lighting for a small reading corner","image":""}' \
+  http://127.0.0.1:18081/
 ```
 
-然后访问 `http://localhost:8080`。
+停止：
 
-### 7.3 构建与运行（Kubernetes）
+```bash
+make local-demo-stop
+```
+
+完整说明见 [docs/local-demo.md](docs/local-demo.md)。
+
+### 2. 本地 Kubernetes smoke
+
+```bash
+make check-e2e
+```
+
+该路径使用 kind + Skaffold + Kustomize，启用 AI assistant 和 mock Ollama，覆盖首页、商品页、加购、结算和 `/bot` 助手请求。手动步骤见 [docs/kind-skaffold-kustomize.md](docs/kind-skaffold-kustomize.md)。
+
+### 3. 默认 Kubernetes 部署
 
 ```bash
 skaffold run
+kubectl port-forward deployment/frontend 8080:8080
 ```
 
-### 7.4 启用 loadgenerator
+访问 `http://127.0.0.1:8080`。
+
+## 多语言服务矩阵
+
+| 服务 | 语言 | 职责 | 改造重点 |
+|---|---|---|---|
+| `frontend` | Go | Web 入口、页面渲染、购物助手转发 | `/assistant`、`/bot`、商品元数据卡片 |
+| `shoppingassistantservice` | Python | AI 购物助手 | Gemini/Ollama、JSON/AlloyDB 检索、healthz、metrics、fallback |
+| `productcatalogservice` | Go | 商品目录 | JSON catalog、本地/AlloyDB 数据路径 |
+| `cartservice` | C# | 购物车 | Redis/外部存储切换 |
+| `checkoutservice` | Go | 结算编排 | gRPC 调用链和金额计算测试 |
+| `paymentservice` | Node.js | 支付模拟 | Node 20、包元信息和基础测试 |
+| `currencyservice` | Node.js | 汇率转换 | Node 20、汇率数据测试 |
+| `shippingservice` | Go | 运费模拟 | Go 单测 |
+| `emailservice` | Python | 邮件模拟 | Python gRPC 服务 |
+| `recommendationservice` | Python | 商品推荐 | Python gRPC 服务 |
+| `adservice` | Java | 广告推荐 | `com.however.microservices` 包迁移、Gradle/PMD |
+| `loadgenerator` | Python | 性能流量 | Locust baseline |
+
+## AI 助手设计
+
+```mermaid
+flowchart LR
+  U["Browser / assistant page"] --> F["frontend /bot"]
+  F --> SA["shoppingassistantservice"]
+  SA --> M{"MODEL_PROVIDER"}
+  M --> G["Gemini"]
+  M --> O["Ollama"]
+  SA --> R{"VECTORSTORE_BACKEND"}
+  R --> A["AlloyDB vector store"]
+  R --> J["JSON catalog fallback"]
+  SA --> H["/healthz /readyz /livez /metrics"]
+```
+
+关键配置：
+
+| 变量 | 作用 |
+|---|---|
+| `MODEL_PROVIDER=gemini\|ollama` | 切换云端 Gemini 或本地 Ollama |
+| `OLLAMA_BASE_URL` / `OLLAMA_MODEL` | 本地模型端点和模型名 |
+| `OLLAMA_ALLOWED_HOSTS` | 限制可访问的 Ollama host |
+| `VECTORSTORE_BACKEND=alloydb\|json` | 切换 AlloyDB 向量检索或 JSON fallback |
+| `PRODUCT_CATALOG_JSON` | JSON 商品数据路径 |
+| `MAX_RETRIES` / `CIRCUIT_BREAKER_*` | 错误重试和降级保护 |
+
+## 部署路径
+
+| 路径 | 入口 | 场景 |
+|---|---|---|
+| Local demo | `make local-demo` | 本机 Redis/Ollama/JSON 助手演示 |
+| Raw manifests | `kubernetes-manifests/` | 最小 Kubernetes 部署 |
+| Kustomize | `kustomize/components/*` | AI assistant、local endpoints、network policies、cloud operations 等组合 |
+| Skaffold | `skaffold.yaml` | 本地或 GKE 构建部署 |
+| Helm | `helm-chart/` | 实验性 Helm 部署路径 |
+| Terraform | `terraform/` | GKE + 可选 Memorystore 基础设施 |
+
+## 与上游的差异
+
+完整证据链见 [docs/diff-from-upstream.md](docs/diff-from-upstream.md)。摘要如下：
+
+- 明确保留 Google Online Boutique 的 Apache-2.0 来源和多语言微服务基线。
+- 迁移 however 命名空间、Java 包名、Gradle group、Node package 元信息和仓库 profile。
+- 新增 AI Shopping Assistant，接入 frontend，并提供模型后端切换。
+- 支持 Gemini/Ollama、AlloyDB/JSON catalog fallback。
+- 新增本地 Redis + Ollama + JSON 演示路径。
+- 增强 Kustomize components、Helm/Terraform 文档、kind smoke、loadgenerator 性能基线。
+- 新增 `ubuntu-latest` 快速多语言 CI，并清理旧式 `::set-env`。
+
+## 质量与 CI
+
+本地快速检查：
 
 ```bash
-skaffold run --module loadgenerator
+make check-python
+make check-node
+make check-java
+bash tests/repo_contract_test.sh
 ```
 
----
-
-## 8. 配置说明（数据库/Redis/Ollama）
-
-建议先复制配置模板并按环境覆盖：
-
-```bash
-cp configs/however.env.example .env.local
-```
-
-关键变量：
-
-- Redis：`REDIS_ADDR`
-- 模型后端：`MODEL_PROVIDER`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`
-- 向量检索：`VECTORSTORE_BACKEND`, `VECTOR_TOP_K`
-- AlloyDB：`PROJECT_ID`, `REGION`, `ALLOYDB_*`
-
-`shoppingassistantservice` 配置逻辑：
-
-1. `MODEL_PROVIDER=gemini` 时走 Gemini。  
-2. `MODEL_PROVIDER=ollama` 时走本地 Ollama API。  
-3. `VECTORSTORE_BACKEND=alloydb` 时使用 AlloyDB 向量检索。  
-4. AlloyDB 不可用时自动回退 `products.local.json`。
-
----
-
-## 9. 部署方式
-
-### 9.1 默认部署
-
-- 使用 `kubernetes-manifests` 或 `skaffold.yaml` 原生部署。
-
-### 9.2 本地依赖覆盖部署
-
-- 新增组件：`kustomize/components/local-endpoints`
-- 用于切换到本地 Redis + Ollama + JSON 检索回退。
-
-示例：
-
-```yaml
-components:
-  - ../components/local-endpoints
-```
-
----
-
-## 10. 与原版差异
-
-1. 增加 `however` 命名体系（构建标识与 Java 包）。  
-2. 购物助手改为可切换模型后端（Gemini / Ollama）。  
-3. 增加检索后端回退机制（AlloyDB -> JSON）。  
-4. 增加本地化配置模板，敏感参数统一外置。  
-5. 增加本地端点覆盖组件，减少清单硬改。  
-6. 文档全面中文化并补充工程化说明。
-
----
-
-## 11. 仓库信息与协议
-
-- 上游协议：`LICENSE`（Apache-2.0）
-- 本仓库衍生说明：`LICENSE-HOWEVER.md`
-- 仓库描述 / Topics 建议：`.github/HOWEVER_REPO_PROFILE.md`
-
----
-
-## 12. 质量检测与验证
-
-统一检测入口：
-
-```bash
-bash scripts/checks/run_all_checks.sh
-```
-
-或使用 Makefile：
+完整聚合入口：
 
 ```bash
 make check-all
 ```
 
-相关文档：
+CI 入口：
 
-- 落地清单：`docs/implementation-checklist.md`
-- 测试说明：`docs/testing-and-quality.md`
+- [.github/workflows/quick-ci.yaml](.github/workflows/quick-ci.yaml)：Go、Node、Python、Java 基础测试，运行在 `ubuntu-latest`。
+- [.github/workflows/shoppingassistant-quality-ci.yaml](.github/workflows/shoppingassistant-quality-ci.yaml)：AI 助手 ruff/mypy/pytest。
+- [.github/workflows/repo-contract-ci.yml](.github/workflows/repo-contract-ci.yml)：仓库质量契约。
 
-## Baseline Maintenance
+## 性能基线
 
-### Environment
-
-- Put runtime credentials in environment variables.
-- Use `.env.example` as the configuration template.
-
-### CI
-
-- `baseline-ci.yml` provides a unified pipeline with `lint + build + test + secret scan`.
-
-### Repo Hygiene
-
-- Keep generated files (`dist/`, `build/`, `__pycache__/`, `.idea/`, `.DS_Store`) out of version control.
-## Engineering Quality
-
-This repository includes a contract-based quality baseline to keep essential engineering standards stable over time.
-
-- Quality plan: [docs/ENGINEERING_QUALITY.md](docs/ENGINEERING_QUALITY.md)
-- Contract tests: [tests/repo_contract_test.sh](tests/repo_contract_test.sh)
-- Contract CI workflow: [.github/workflows/repo-contract-ci.yml](.github/workflows/repo-contract-ci.yml)
-
-Run local contract checks:
+生成模板：
 
 ```bash
-bash tests/repo_contract_test.sh
+./scripts/perf/generate_baseline_report.sh reports/performance/baseline-latest.md
 ```
+
+运行 `loadgenerator`：
+
+```bash
+skaffold run --module loadgenerator
+kubectl logs -l app=loadgenerator -f
+```
+
+说明见 [docs/performance-baseline.md](docs/performance-baseline.md)。
+
+## Release baseline
+
+本仓库的第一条建议发布线是 `AI microservices lab baseline`，突出：
+
+- 多语言微服务工程改造能力
+- Kubernetes/Skaffold/Kustomize 部署能力
+- Gemini/Ollama AI 服务集成能力
+- JSON fallback 和错误降级质量能力
+
+Release note 草稿见 [docs/releasing/ai-microservices-lab-baseline.md](docs/releasing/ai-microservices-lab-baseline.md)。
+
+## 协议
+
+- 上游协议：[LICENSE](LICENSE)
+- however 衍生说明：[LICENSE-HOWEVER.md](LICENSE-HOWEVER.md)

--- a/docker-compose.local-demo.yml
+++ b/docker-compose.local-demo.yml
@@ -1,0 +1,27 @@
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: however-local-redis
+    ports:
+      - "${LOCAL_DEMO_REDIS_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 20
+
+  ollama:
+    image: ollama/ollama:latest
+    container_name: however-local-ollama
+    ports:
+      - "${LOCAL_DEMO_OLLAMA_PORT:-11434}:11434"
+    volumes:
+      - ollama-data:/root/.ollama
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+
+volumes:
+  ollama-data:

--- a/docs/diff-from-upstream.md
+++ b/docs/diff-from-upstream.md
@@ -1,0 +1,184 @@
+# 与上游 Google Online Boutique 的差异说明
+
+本文档用于说明 `however-microservices-lab` 的上游来源、保留边界和工程改造点。目标是让读者可以快速确认：本仓库不是简单改名，而是在 Online Boutique 的多语言微服务样板之上，扩展成一个“云原生微服务 + AI 集成实验室”。
+
+## 1. 上游来源与保留边界
+
+- 上游项目：GoogleCloudPlatform/microservices-demo，也就是 Google Online Boutique。
+- 上游协议：Apache License 2.0，本仓库保留根目录 [LICENSE](../LICENSE)。
+- 衍生说明：本仓库新增 [LICENSE-HOWEVER.md](../LICENSE-HOWEVER.md)，用于说明 however 侧新增文档、脚本、配置和实验室定位。
+- 保留的上游价值：多语言服务边界、gRPC 协议、Kubernetes 部署清单、Skaffold 构建方式、负载生成器和基础电商业务链路。
+- 改造目标：把上游电商样例升级为可本地演示、可切换 AI 后端、可做 K8s 工程实践和 CI 质量演示的实验室。
+
+## 2. 命名空间与仓库身份迁移
+
+| 范围 | 上游形态 | however 改造 |
+|---|---|---|
+| 仓库定位 | Online Boutique demo | however microservices lab |
+| Java 包名 | `hipstershop.*` | `com.however.microservices.adservice.*` |
+| Gradle group | 上游包组织 | `com.however.microservices` |
+| Java artifact | `adservice` | `however-adservice` |
+| Node package | 上游服务名 | `however-currencyservice`、`however-paymentservice` |
+| 文档入口 | Online Boutique README | AI microservices lab README |
+
+可核验文件：
+
+- [src/adservice/build.gradle](../src/adservice/build.gradle)
+- [src/adservice/settings.gradle](../src/adservice/settings.gradle)
+- [src/adservice/src/main/java/com/however/microservices/adservice/AdService.java](../src/adservice/src/main/java/com/however/microservices/adservice/AdService.java)
+- [src/currencyservice/package.json](../src/currencyservice/package.json)
+- [src/paymentservice/package.json](../src/paymentservice/package.json)
+- [.github/HOWEVER_REPO_PROFILE.md](../.github/HOWEVER_REPO_PROFILE.md)
+
+## 3. 配置外置与本地化
+
+上游样例主要面向云端演示，本仓库把更多运行参数外置，便于本地、kind、GKE 和 CI 之间切换。
+
+| 配置面 | 改造点 | 文件 |
+|---|---|---|
+| 通用环境模板 | 新增 `configs/however.env.example`，集中 Redis、Ollama、Gemini、AlloyDB、Tracing、Rate limit 等变量 | [configs/however.env.example](../configs/however.env.example) |
+| 本地演示 | 新增 `docker-compose.local-demo.yml` 和 `make local-demo`，拉起本地 Redis/Ollama 并用 JSON catalog 启动助手服务 | [docker-compose.local-demo.yml](../docker-compose.local-demo.yml), [scripts/local-demo.sh](../scripts/local-demo.sh) |
+| K8s 本地端点 | Kustomize component 覆盖 `REDIS_ADDR`、`OLLAMA_BASE_URL`、`VECTORSTORE_BACKEND=json` | [kustomize/components/local-endpoints/kustomization.yaml](../kustomize/components/local-endpoints/kustomization.yaml) |
+| 运行时探针 | AI 服务新增 `/healthz`、`/readyz`、`/livez` 和 Prometheus `/metrics` | [src/shoppingassistantservice/shoppingassistantservice.py](../src/shoppingassistantservice/shoppingassistantservice.py) |
+
+## 4. Shopping Assistant 新服务
+
+上游 Online Boutique 的主链路是电商浏览、购物车、结算和推荐。本仓库新增 `shoppingassistantservice`，把 AI 购物助手作为独立服务接入前端。
+
+新增能力：
+
+- 前端增加 `/assistant` 页面和 `/bot` HTTP 转发入口。
+- 助手支持文字需求和图片 URL/Base64 输入。
+- Python Flask 服务提供请求校验、模型调用、商品检索、推荐 ID 规范化、健康检查和 Prometheus 指标。
+- 前端可根据模型返回的 `[product_id]` 自动拉取商品元数据并展示商品卡片。
+- 服务内置限流、重试、熔断和错误降级。
+
+可核验文件：
+
+- [src/frontend/templates/assistant.html](../src/frontend/templates/assistant.html)
+- [src/frontend/handlers.go](../src/frontend/handlers.go)
+- [src/shoppingassistantservice/shoppingassistantservice.py](../src/shoppingassistantservice/shoppingassistantservice.py)
+- [src/shoppingassistantservice/model_client.py](../src/shoppingassistantservice/model_client.py)
+- [src/shoppingassistantservice/retriever.py](../src/shoppingassistantservice/retriever.py)
+
+## 5. Gemini/Ollama 可切换模型后端
+
+`shoppingassistantservice` 通过 `MODEL_PROVIDER` 切换模型后端：
+
+| 后端 | 使用场景 | 关键变量 |
+|---|---|---|
+| `gemini` | 云端 Gemini 推理，适合 GKE/AlloyDB/RAG 演示 | `MODEL_PROVIDER=gemini`, `GEMINI_VISION_MODEL`, `GEMINI_TEXT_MODEL`, `GOOGLE_API_KEY` |
+| `ollama` | 本地或内网模型推理，适合离线演示和面试作品展示 | `MODEL_PROVIDER=ollama`, `OLLAMA_BASE_URL`, `OLLAMA_MODEL`, `OLLAMA_ALLOWED_HOSTS` |
+
+安全与可靠性改造：
+
+- `OLLAMA_ALLOWED_HOSTS` 限制可访问的 Ollama 主机，避免任意 URL 转发。
+- 模型调用失败时返回保护模式文案，不让前端直接暴露异常堆栈。
+- `MAX_RETRIES`、`RETRY_BACKOFF_SECONDS`、`CIRCUIT_BREAKER_*` 可调。
+
+测试覆盖：
+
+- Ollama endpoint/payload 契约。
+- Gemini provider 契约。
+- 模型失败降级。
+- 健康检查和 readiness/liveness contract。
+
+可核验文件：
+
+- [src/shoppingassistantservice/tests/test_shoppingassistantservice_unit.py](../src/shoppingassistantservice/tests/test_shoppingassistantservice_unit.py)
+- [src/shoppingassistantservice/tests/test_shoppingassistantservice_contract.py](../src/shoppingassistantservice/tests/test_shoppingassistantservice_contract.py)
+
+## 6. JSON catalog fallback
+
+上游商品目录默认来自本地 `products.json` 或云端扩展。本仓库把 fallback 显式做成 AI 服务质量策略：
+
+- `productcatalogservice` 仍保留本地 `products.json` 作为商品目录基础数据。
+- `shoppingassistantservice` 新增 `products.local.json`，用于本地 RAG-like 检索和 CI 测试。
+- `VECTORSTORE_BACKEND=alloydb` 时会优先尝试 AlloyDB Vector Store。
+- AlloyDB 配置不完整或初始化失败时，助手自动切换到 JSON catalog。
+- JSON 检索会按 query token 与商品名称、描述、分类的重合度排序，返回可解释的候选商品。
+
+可核验文件：
+
+- [src/productcatalogservice/products.json](../src/productcatalogservice/products.json)
+- [src/productcatalogservice/catalog_loader.go](../src/productcatalogservice/catalog_loader.go)
+- [src/shoppingassistantservice/products.local.json](../src/shoppingassistantservice/products.local.json)
+- [src/shoppingassistantservice/retriever.py](../src/shoppingassistantservice/retriever.py)
+
+## 7. Kustomize 改造点
+
+| 组件 | 作用 |
+|---|---|
+| `shopping-assistant` | 新增 AI 助手 Deployment、Service、ServiceAccount、Secret，并给 frontend 打开 `ENABLE_ASSISTANT=true` |
+| `local-endpoints` | 将 Redis/Ollama/JSON catalog 指向本地演示依赖 |
+| `shopping-assistant-canary` | 提供助手服务并行 canary 部署模板 |
+| `network-policies` | 保留并增强微服务网络隔离实验 |
+| `google-cloud-operations` | 保留云端可观测性路径 |
+
+可核验文件：
+
+- [kustomize/components/shopping-assistant/kustomization.yaml](../kustomize/components/shopping-assistant/kustomization.yaml)
+- [kustomize/components/local-endpoints/kustomization.yaml](../kustomize/components/local-endpoints/kustomization.yaml)
+- [tests/e2e/kustomize/kustomization.yaml](../tests/e2e/kustomize/kustomization.yaml)
+
+## 8. Helm 改造点
+
+Helm chart 保留上游多服务部署结构，并做了 however 化：
+
+- Chart 名称与说明改为 `however-microservices-lab`。
+- `values.yaml` 暴露镜像、资源、Redis、服务开关等配置。
+- `shoppingAssistantService` 作为显式实验项保留，目前推荐通过 Kustomize component 启用，避免 Helm 路径和 AI/AlloyDB 路径发生双重维护。
+
+可核验文件：
+
+- [helm-chart/Chart.yaml](../helm-chart/Chart.yaml)
+- [helm-chart/values.yaml](../helm-chart/values.yaml)
+- [helm-chart/README.md](../helm-chart/README.md)
+
+## 9. Terraform 改造点
+
+Terraform 路径保留上游 GKE 部署能力，并加入 however 文档化和可选云依赖：
+
+- 文档入口改为 `however-microservices-lab`。
+- Memorystore Redis 可选，用于替换集群内 Redis。
+- 仍可与 Kustomize/Skaffold 路径组合，用于展示从本地到 GKE 的部署迁移。
+
+可核验文件：
+
+- [terraform/README.md](../terraform/README.md)
+- [terraform/memorystore.tf](../terraform/memorystore.tf)
+- [terraform/variables.tf](../terraform/variables.tf)
+
+## 10. CI 改造点
+
+上游 CI 偏向 Google 自有 self-hosted runner 和 GKE staging。本仓库保留这种重部署路径，同时新增不依赖 self-hosted runner 的快速质量基线。
+
+| 工作流 | 改造目的 |
+|---|---|
+| `quick-ci.yaml` | 在 `ubuntu-latest` 上跑 Go、Node、Python、Java 基础测试 |
+| `shoppingassistant-quality-ci.yaml` | 专门保护 AI 助手的 ruff/mypy/pytest |
+| `adservice-quality-ci.yaml` | 保护 Java 包名迁移后的 Gradle 测试和 PMD |
+| `node-service-tests-ci.yaml` | 保护 Node 服务元信息和单测 |
+| `repo-contract-ci.yml` | 保护仓库工程质量清单 |
+| `ci-pr.yaml` / `ci-main.yaml` | 清理旧式 `::set-env`，改用 `$GITHUB_ENV` |
+
+可核验文件：
+
+- [.github/workflows/quick-ci.yaml](../.github/workflows/quick-ci.yaml)
+- [.github/workflows/ci-pr.yaml](../.github/workflows/ci-pr.yaml)
+- [.github/workflows/ci-main.yaml](../.github/workflows/ci-main.yaml)
+
+## 11. 质量基线与演示证据
+
+本仓库用以下材料证明改造是可运行、可测试、可交付的工程样板：
+
+- 本地演示：`make local-demo`
+- 快速多语言 CI：`.github/workflows/quick-ci.yaml`
+- AI 助手测试：`src/shoppingassistantservice/tests/`
+- kind + Skaffold smoke：`tests/e2e/kind_skaffold_smoke.sh`
+- 性能基线模板：`docs/performance-baseline.md` 和 `reports/performance/baseline-latest.md`
+- 发布说明草稿：`docs/releasing/ai-microservices-lab-baseline.md`
+
+## 12. 一句话结论
+
+`however-microservices-lab` 的核心差异不是名称，而是把 Online Boutique 从“电商微服务样例”扩展为“多语言微服务工程改造样板”：它同时覆盖 AI 服务集成、本地 Ollama 演示、JSON catalog fallback、Kubernetes 组件化部署、云资源路径、快速 CI 和性能基线。

--- a/docs/diff-from-upstream.md
+++ b/docs/diff-from-upstream.md
@@ -160,7 +160,7 @@ Terraform 路径保留上游 GKE 部署能力，并加入 however 文档化和�
 | `adservice-quality-ci.yaml` | 保护 Java 包名迁移后的 Gradle 测试和 PMD |
 | `node-service-tests-ci.yaml` | 保护 Node 服务元信息和单测 |
 | `repo-contract-ci.yml` | 保护仓库工程质量清单 |
-| `ci-pr.yaml` / `ci-main.yaml` | 清理旧式 `::set-env`，改用 `$GITHUB_ENV` |
+| `ci-pr.yaml` / `ci-main.yaml` | 清理旧式 `::set-env`，改用 `$GITHUB_ENV`；旧 GKE PR staging 改为手动触发，避免 PR 默认依赖 self-hosted runner |
 
 可核验文件：
 

--- a/docs/img/assistant-screenshot.svg
+++ b/docs/img/assistant-screenshot.svg
@@ -1,0 +1,63 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="620" viewBox="0 0 980 620" role="img" aria-labelledby="title desc">
+  <title id="title">AI shopping assistant screenshot</title>
+  <desc id="desc">Stylized screenshot of the AI shopping assistant using Ollama and JSON catalog fallback to return product recommendations.</desc>
+  <defs>
+    <style>
+      .screen { fill: #f6f8fb; stroke: #cbd5e1; stroke-width: 2; }
+      .side { fill: #2b1530; }
+      .chat { fill: #ffffff; stroke: #d8e0ea; }
+      .bot { fill: #ffffff; stroke: #d8e0ea; }
+      .user { fill: #0b66d7; }
+      .chip { fill: rgba(255,255,255,0.14); stroke: rgba(255,255,255,0.32); }
+      .product { fill: #f8fafc; stroke: #d8e0ea; }
+      .title { font: 700 30px Arial, sans-serif; fill: #ffffff; }
+      .label { font: 700 16px Arial, sans-serif; fill: #172033; }
+      .small { font: 13px Arial, sans-serif; fill: #64748b; }
+      .white { fill: #ffffff; font: 13px Arial, sans-serif; }
+      .trace { fill: #64748b; font: 11px Arial, sans-serif; }
+    </style>
+  </defs>
+  <rect x="18" y="18" width="944" height="584" rx="28" class="screen"/>
+  <rect x="48" y="54" width="282" height="512" rx="22" class="side"/>
+  <text x="78" y="112" class="title">AI Shopping Assistant</text>
+  <text x="78" y="146" class="white">Ollama or Gemini model backend</text>
+  <text x="78" y="170" class="white">JSON catalog fallback for local demos</text>
+  <rect x="78" y="224" width="205" height="42" rx="12" class="chip"/>
+  <text x="98" y="250" class="white">Minimalist desk setup</text>
+  <rect x="78" y="286" width="205" height="42" rx="12" class="chip"/>
+  <text x="98" y="312" class="white">Gift for a coffee lover</text>
+  <rect x="78" y="348" width="205" height="42" rx="12" class="chip"/>
+  <text x="98" y="374" class="white">Cozy small apartment</text>
+  <rect x="78" y="472" width="188" height="46" rx="12" fill="#22c55e"/>
+  <text x="102" y="501" class="white">healthz ready</text>
+
+  <rect x="366" y="54" width="566" height="512" rx="22" class="chat"/>
+  <rect x="394" y="88" width="286" height="64" rx="16" class="bot"/>
+  <text x="414" y="116" class="label">Hi, I can recommend products.</text>
+  <text x="414" y="138" class="small">Tell me a room style, budget, or use case.</text>
+  <rect x="585" y="182" width="310" height="68" rx="16" class="user"/>
+  <text x="610" y="212" class="white">Recommend warm lighting for a</text>
+  <text x="610" y="235" class="white">small reading corner.</text>
+  <rect x="394" y="282" width="390" height="106" rx="16" class="bot"/>
+  <text x="414" y="312" class="label">Warm minimalist style detected.</text>
+  <text x="414" y="338" class="small">Try a focused desk lamp and soft neutral accessories.</text>
+  <text x="414" y="364" class="trace">trace 4f1f8b2a - provider ollama - backend json</text>
+
+  <rect x="394" y="414" width="154" height="96" rx="14" class="product"/>
+  <rect x="412" y="432" width="42" height="42" rx="10" fill="#eef7ff"/>
+  <text x="468" y="452" class="label">Desk lamp</text>
+  <text x="468" y="474" class="small">[2ZYFJ3GM2N]</text>
+  <rect x="574" y="414" width="154" height="96" rx="14" class="product"/>
+  <rect x="592" y="432" width="42" height="42" rx="10" fill="#fff6e6"/>
+  <text x="648" y="452" class="label">Throw blanket</text>
+  <text x="648" y="474" class="small">[OLJCESPC7Z]</text>
+  <rect x="754" y="414" width="154" height="96" rx="14" class="product"/>
+  <rect x="772" y="432" width="42" height="42" rx="10" fill="#edfdf5"/>
+  <text x="828" y="452" class="label">Coffee kit</text>
+  <text x="828" y="474" class="small">[LS4PSXUNUM]</text>
+
+  <rect x="394" y="526" width="420" height="28" rx="14" fill="#f1f5f9"/>
+  <text x="414" y="545" class="small">Ask for bundles, price range, style, image URL or upload.</text>
+  <rect x="830" y="522" width="78" height="36" rx="12" fill="#0b66d7"/>
+  <text x="856" y="545" class="white">Send</text>
+</svg>

--- a/docs/img/frontend-screenshot.svg
+++ b/docs/img/frontend-screenshot.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="620" viewBox="0 0 980 620" role="img" aria-labelledby="title desc">
+  <title id="title">however frontend screenshot</title>
+  <desc id="desc">Stylized screenshot of the however microservices lab shopping frontend with product cards and AI assistant entry point.</desc>
+  <defs>
+    <style>
+      .screen { fill: #f7f9fc; stroke: #cbd5e1; stroke-width: 2; }
+      .nav { fill: #172033; }
+      .panel { fill: #ffffff; stroke: #d8e0ea; }
+      .primary { fill: #0b66d7; }
+      .accent { fill: #f59e0b; }
+      .muted { fill: #e7edf5; }
+      .title { font: 700 32px Arial, sans-serif; fill: #172033; }
+      .h { font: 700 17px Arial, sans-serif; fill: #172033; }
+      .small { font: 13px Arial, sans-serif; fill: #5f6f82; }
+      .white { fill: #ffffff; font: 700 14px Arial, sans-serif; }
+    </style>
+  </defs>
+  <rect x="18" y="18" width="944" height="584" rx="28" class="screen"/>
+  <rect x="18" y="18" width="944" height="72" rx="28" class="nav"/>
+  <circle cx="62" cy="54" r="17" fill="#22c55e"/>
+  <text x="92" y="60" class="white">however shop</text>
+  <text x="704" y="60" class="white">AI Assistant</text>
+  <rect x="826" y="36" width="92" height="34" rx="17" fill="#ffffff"/>
+  <text x="850" y="58" class="small">Cart 2</text>
+
+  <text x="58" y="146" class="title">Cloud native shopping lab</text>
+  <text x="58" y="178" class="small">Go frontend, gRPC services, Redis cart, JSON catalog fallback and optional AI shopping assistant.</text>
+  <rect x="58" y="210" width="182" height="44" rx="10" class="primary"/>
+  <text x="82" y="238" class="white">Ask AI Concierge</text>
+  <rect x="260" y="210" width="150" height="44" rx="10" fill="#ffffff" stroke="#cbd5e1"/>
+  <text x="286" y="238" class="small">Browse catalog</text>
+
+  <rect x="58" y="302" width="250" height="228" rx="16" class="panel"/>
+  <rect x="82" y="326" width="202" height="104" rx="14" class="muted"/>
+  <circle cx="183" cy="378" r="34" fill="#94a3b8"/>
+  <text x="82" y="468" class="h">Vintage camera</text>
+  <text x="82" y="494" class="small">JSON catalog item</text>
+  <text x="82" y="518" class="small">$49.99</text>
+
+  <rect x="365" y="302" width="250" height="228" rx="16" class="panel"/>
+  <rect x="389" y="326" width="202" height="104" rx="14" fill="#eef7ff"/>
+  <path d="M428 398 C462 350 510 354 552 398 Z" class="primary"/>
+  <text x="389" y="468" class="h">Desk lamp</text>
+  <text x="389" y="494" class="small">Assistant-ready product</text>
+  <text x="389" y="518" class="small">$34.50</text>
+
+  <rect x="672" y="302" width="250" height="228" rx="16" class="panel"/>
+  <rect x="696" y="326" width="202" height="104" rx="14" fill="#fff6e6"/>
+  <rect x="740" y="362" width="110" height="44" rx="10" class="accent"/>
+  <text x="696" y="468" class="h">Coffee gift kit</text>
+  <text x="696" y="494" class="small">Recommended bundle</text>
+  <text x="696" y="518" class="small">$65.00</text>
+</svg>

--- a/docs/img/however-architecture.svg
+++ b/docs/img/however-architecture.svg
@@ -1,0 +1,101 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1180" height="680" viewBox="0 0 1180 680" role="img" aria-labelledby="title desc">
+  <title id="title">however-microservices-lab architecture</title>
+  <desc id="desc">Cloud native microservices architecture with AI shopping assistant, Gemini or Ollama model backends, JSON or AlloyDB catalog retrieval, Redis cart storage, Kubernetes, Kustomize, Helm, Terraform and CI.</desc>
+  <defs>
+    <style>
+      .bg { fill: #f6f8fb; }
+      .band { fill: #ffffff; stroke: #d8e0ea; stroke-width: 1.5; }
+      .svc { fill: #ffffff; stroke: #93a4b8; stroke-width: 1.5; }
+      .ai { fill: #eef7ff; stroke: #1f77b4; stroke-width: 1.8; }
+      .data { fill: #fff6e6; stroke: #c27a1a; stroke-width: 1.6; }
+      .ops { fill: #edfdf5; stroke: #2f8f5b; stroke-width: 1.6; }
+      .title { font: 700 28px Arial, sans-serif; fill: #172033; }
+      .label { font: 700 15px Arial, sans-serif; fill: #172033; }
+      .small { font: 12px Arial, sans-serif; fill: #516173; }
+      .tiny { font: 11px Arial, sans-serif; fill: #64748b; }
+      .arrow { stroke: #62748a; stroke-width: 2; fill: none; marker-end: url(#arrow); }
+      .dash { stroke-dasharray: 6 6; }
+    </style>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto" markerUnits="strokeWidth">
+      <path d="M0,0 L0,6 L9,3 z" fill="#62748a" />
+    </marker>
+  </defs>
+  <rect class="bg" width="1180" height="680" rx="26"/>
+  <text x="44" y="58" class="title">however-microservices-lab</text>
+  <text x="44" y="84" class="small">Cloud native microservices + AI integration baseline, derived from Google Online Boutique and extended as an engineering lab.</text>
+
+  <rect x="40" y="118" width="260" height="478" rx="18" class="band"/>
+  <text x="68" y="152" class="label">Experience Layer</text>
+  <rect x="72" y="190" width="188" height="76" rx="12" class="svc"/>
+  <text x="96" y="220" class="label">frontend</text>
+  <text x="96" y="244" class="small">Go HTTP + templates</text>
+  <rect x="72" y="304" width="188" height="76" rx="12" class="svc"/>
+  <text x="96" y="334" class="label">loadgenerator</text>
+  <text x="96" y="358" class="small">Python Locust baseline</text>
+  <rect x="72" y="418" width="188" height="76" rx="12" class="ai"/>
+  <text x="96" y="448" class="label">AI Assistant UI</text>
+  <text x="96" y="472" class="small">Prompt + image input</text>
+
+  <rect x="342" y="118" width="424" height="478" rx="18" class="band"/>
+  <text x="370" y="152" class="label">Business Services</text>
+  <rect x="374" y="188" width="160" height="64" rx="12" class="svc"/>
+  <text x="396" y="216" class="label">cartservice</text>
+  <text x="396" y="236" class="tiny">C# gRPC</text>
+  <rect x="574" y="188" width="160" height="64" rx="12" class="svc"/>
+  <text x="596" y="216" class="label">checkoutservice</text>
+  <text x="596" y="236" class="tiny">Go orchestration</text>
+  <rect x="374" y="286" width="160" height="64" rx="12" class="svc"/>
+  <text x="396" y="314" class="label">catalog</text>
+  <text x="396" y="334" class="tiny">Go JSON/AlloyDB</text>
+  <rect x="574" y="286" width="160" height="64" rx="12" class="svc"/>
+  <text x="596" y="314" class="label">recommendation</text>
+  <text x="596" y="334" class="tiny">Python gRPC</text>
+  <rect x="374" y="384" width="160" height="64" rx="12" class="svc"/>
+  <text x="396" y="412" class="label">payment</text>
+  <text x="396" y="432" class="tiny">Node.js gRPC</text>
+  <rect x="574" y="384" width="160" height="64" rx="12" class="svc"/>
+  <text x="596" y="412" class="label">currency</text>
+  <text x="596" y="432" class="tiny">Node.js gRPC</text>
+  <rect x="374" y="482" width="160" height="64" rx="12" class="svc"/>
+  <text x="396" y="510" class="label">shipping</text>
+  <text x="396" y="530" class="tiny">Go gRPC</text>
+  <rect x="574" y="482" width="160" height="64" rx="12" class="svc"/>
+  <text x="596" y="510" class="label">adservice</text>
+  <text x="596" y="530" class="tiny">Java gRPC</text>
+
+  <rect x="808" y="118" width="332" height="478" rx="18" class="band"/>
+  <text x="836" y="152" class="label">AI + Data + Delivery</text>
+  <rect x="842" y="188" width="260" height="78" rx="12" class="ai"/>
+  <text x="864" y="218" class="label">shoppingassistantservice</text>
+  <text x="864" y="242" class="small">Python Flask, healthz, metrics, fallback</text>
+  <rect x="842" y="304" width="118" height="70" rx="12" class="ai"/>
+  <text x="872" y="334" class="label">Gemini</text>
+  <text x="872" y="354" class="tiny">cloud model</text>
+  <rect x="984" y="304" width="118" height="70" rx="12" class="ai"/>
+  <text x="1014" y="334" class="label">Ollama</text>
+  <text x="1014" y="354" class="tiny">local model</text>
+  <rect x="842" y="410" width="118" height="70" rx="12" class="data"/>
+  <text x="878" y="440" class="label">JSON</text>
+  <text x="866" y="460" class="tiny">local catalog</text>
+  <rect x="984" y="410" width="118" height="70" rx="12" class="data"/>
+  <text x="1022" y="440" class="label">AlloyDB</text>
+  <text x="1012" y="460" class="tiny">vector store</text>
+  <rect x="842" y="514" width="260" height="46" rx="12" class="ops"/>
+  <text x="864" y="543" class="label">Kustomize, Helm, Terraform, CI</text>
+
+  <path class="arrow" d="M260 228 C296 228 314 220 374 220"/>
+  <path class="arrow" d="M260 456 C356 456 744 226 842 226"/>
+  <path class="arrow" d="M534 220 H574"/>
+  <path class="arrow" d="M454 252 V286"/>
+  <path class="arrow" d="M654 252 V286"/>
+  <path class="arrow" d="M654 350 V384"/>
+  <path class="arrow" d="M454 350 V384"/>
+  <path class="arrow" d="M734 318 C780 318 802 250 842 250"/>
+  <path class="arrow" d="M972 266 V304"/>
+  <path class="arrow" d="M972 266 C1028 270 1044 284 1044 304"/>
+  <path class="arrow dash" d="M902 266 V410"/>
+  <path class="arrow dash" d="M1010 266 C1042 300 1044 362 1044 410"/>
+  <path class="arrow" d="M454 188 C454 132 112 126 112 190"/>
+  <path class="arrow" d="M454 252 C430 286 410 332 400 384"/>
+  <path class="arrow" d="M534 514 H574"/>
+</svg>

--- a/docs/kind-skaffold-kustomize.md
+++ b/docs/kind-skaffold-kustomize.md
@@ -1,0 +1,121 @@
+# kind + Skaffold + Kustomize 教程
+
+本教程用于在本机 Kubernetes 集群里跑完整多语言微服务链路，并启用 AI Shopping Assistant 的本地化配置。
+
+## 目标
+
+- 使用 kind 创建一次性本地集群。
+- 使用 Skaffold 构建并部署所有服务镜像。
+- 使用 Kustomize 组合基础清单和 AI assistant 组件。
+- 使用 mock Ollama 避免 CI 或演示时下载模型。
+- 使用 frontend `/bot` 验证助手链路。
+
+## 前置条件
+
+```bash
+kind version
+kubectl version --client
+skaffold version
+docker version
+```
+
+## 一键 smoke test
+
+仓库提供封装脚本：
+
+```bash
+make check-e2e
+```
+
+脚本会执行：
+
+1. 创建或复用 `however-microservices-lab-e2e` kind 集群。
+2. 创建 `however-e2e` namespace。
+3. 通过 `skaffold run -p e2e` 部署测试 Kustomize overlay。
+4. 等待 frontend、cartservice、checkoutservice、productcatalogservice、shoppingassistantservice 和 mock Ollama ready。
+5. 通过 port-forward 访问 frontend。
+6. 覆盖首页、商品页、加购、结算和 `/bot` 助手请求。
+
+## 手动部署
+
+创建集群：
+
+```bash
+kind create cluster --name however-microservices-lab-e2e
+kubectl config use-context kind-however-microservices-lab-e2e
+kubectl create namespace however-e2e --dry-run=client -o yaml | kubectl apply -f -
+```
+
+部署：
+
+```bash
+skaffold run -p e2e --namespace however-e2e
+```
+
+等待核心组件：
+
+```bash
+kubectl -n however-e2e wait --for=condition=available --timeout=600s deployment/frontend
+kubectl -n however-e2e wait --for=condition=available --timeout=600s deployment/shoppingassistantservice
+kubectl -n however-e2e wait --for=condition=available --timeout=600s deployment/ollama
+```
+
+访问前端：
+
+```bash
+kubectl -n however-e2e port-forward svc/frontend 18080:80
+```
+
+打开 `http://127.0.0.1:18080`，或直接请求健康检查：
+
+```bash
+curl -fsS http://127.0.0.1:18080/_healthz
+```
+
+验证助手链路：
+
+```bash
+curl -fsS \
+  -H "Content-Type: application/json" \
+  -X POST "http://127.0.0.1:18080/bot" \
+  -d '{"message":"Recommend warm lighting for a small room","image":""}'
+```
+
+## Kustomize overlay 说明
+
+测试 overlay 位于 [tests/e2e/kustomize/kustomization.yaml](../tests/e2e/kustomize/kustomization.yaml)，组合了：
+
+- `../../../kubernetes-manifests`
+- `../../../kustomize/components/shopping-assistant`
+- `mock-ollama.yaml`
+
+关键覆盖：
+
+- `frontend.ENABLE_ASSISTANT=true`
+- `shoppingassistantservice.MODEL_PROVIDER=ollama`
+- `shoppingassistantservice.OLLAMA_BASE_URL=http://ollama:11434`
+- `shoppingassistantservice.VECTORSTORE_BACKEND=json`
+- `shoppingassistantservice.PRODUCT_CATALOG_JSON=/shoppingassistantservice/products.local.json`
+
+## 使用真实本地 Ollama
+
+如果你已经运行本机 Ollama，可以在自己的 Kustomize overlay 中追加：
+
+```yaml
+components:
+  - ../../../kustomize/components/shopping-assistant
+  - ../../../kustomize/components/local-endpoints
+```
+
+该组件会把助手切到：
+
+- `MODEL_PROVIDER=ollama`
+- `OLLAMA_BASE_URL=http://host.docker.internal:11434`
+- `VECTORSTORE_BACKEND=json`
+
+## 清理
+
+```bash
+skaffold delete -p e2e --namespace however-e2e
+kind delete cluster --name however-microservices-lab-e2e
+```

--- a/docs/local-demo.md
+++ b/docs/local-demo.md
@@ -1,0 +1,86 @@
+# 本地演示：Redis + Ollama + JSON Catalog
+
+本地演示目标是快速证明 AI Shopping Assistant 可以脱离云依赖运行：
+
+- Redis 在本机 Docker 中运行，作为购物车依赖的本地替代。
+- Ollama 在本机 Docker 中运行，作为可替换模型后端。
+- `shoppingassistantservice` 使用 `VECTORSTORE_BACKEND=json` 读取本地商品数据。
+- 默认只验证健康检查，避免第一次演示被模型下载拖慢。
+
+## 前置条件
+
+- Docker Desktop 或兼容的 Docker Engine
+- Python 3.11+
+- `curl`
+
+## 启动
+
+```bash
+make local-demo
+```
+
+启动后会得到三个本地端点：
+
+| 组件 | 端点 |
+|---|---|
+| Redis | `127.0.0.1:6379` |
+| Ollama | `http://127.0.0.1:11434` |
+| shoppingassistantservice | `http://127.0.0.1:18081` |
+
+健康检查：
+
+```bash
+curl -sS http://127.0.0.1:18081/healthz
+```
+
+预期能看到：
+
+```json
+{
+  "status": "ok",
+  "model_provider": "ollama",
+  "vectorstore_backend": "json",
+  "circuit_breaker_open": false
+}
+```
+
+## 拉取模型并发起一次真实请求
+
+默认 `make local-demo` 不会拉模型。需要走真实 Ollama 推理时执行：
+
+```bash
+LOCAL_DEMO_PULL_MODEL=1 make local-demo
+```
+
+默认模型是 `qwen2.5:0.5b`，可覆盖：
+
+```bash
+OLLAMA_MODEL=qwen2.5:7b LOCAL_DEMO_PULL_MODEL=1 make local-demo
+```
+
+请求助手：
+
+```bash
+curl -sS \
+  -H "Content-Type: application/json" \
+  -d '{"message":"Recommend warm lighting for a small reading corner","image":""}' \
+  http://127.0.0.1:18081/
+```
+
+返回内容应包含 `content` 和 `trace_id`。如果模型暂时不可用，服务会返回保护模式文案和 `推荐ID: [NO_MATCH]`，而不是让前端暴露异常。
+
+## 停止
+
+```bash
+make local-demo-stop
+```
+
+查看状态：
+
+```bash
+make local-demo-status
+```
+
+## 与 Kubernetes 演示的关系
+
+`make local-demo` 只跑本地依赖和 AI 助手服务，适合快速展示 Gemini/Ollama 切换和 JSON fallback。完整前端、多服务、Kubernetes 编排请使用 [kind + skaffold + kustomize 教程](kind-skaffold-kustomize.md)。

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -1,16 +1,66 @@
-# 性能基线说明
+# Loadgenerator 性能基线说明
 
-本仓库提供性能基线模板脚本：
+本仓库保留 Online Boutique 的 `loadgenerator`，并把它作为 however 微服务实验室的性能基线入口。基线不是压出极限值，而是记录一次可重复的工程状态：吞吐、错误率、助手链路延迟和资源占用。
+
+## 生成报告模板
 
 ```bash
 ./scripts/perf/generate_baseline_report.sh reports/performance/baseline-latest.md
 ```
 
-建议每次发布前记录以下指标：
+## Kubernetes 基线流程
 
-1. `loadgenerator` 总请求数与错误率  
-2. `shoppingassistantservice` 请求耗时分位（p50/p95/p99）  
-3. 资源占用（CPU/内存）  
-4. 关键依赖耗时（Ollama/AlloyDB）
+1. 部署完整应用：
+
+```bash
+skaffold run
+```
+
+2. 启动或更新 loadgenerator：
+
+```bash
+skaffold run --module loadgenerator
+```
+
+3. 观察聚合日志：
+
+```bash
+kubectl logs -l app=loadgenerator -f
+```
+
+4. 记录 Pod 资源：
+
+```bash
+kubectl top pods
+```
+
+5. 如启用了 AI assistant，记录助手指标：
+
+```bash
+kubectl port-forward svc/shoppingassistantservice 18081:80
+curl -sS http://127.0.0.1:18081/metrics | grep shopping_assistant
+```
+
+## 推荐记录项
+
+| 指标 | 来源 |
+|---|---|
+| 总请求数 | `loadgenerator` 聚合日志 |
+| 错误数和错误率 | `loadgenerator` 聚合日志 |
+| `shoppingassistantservice` 请求数 | `shopping_assistant_requests_total` |
+| 助手请求延迟 | `shopping_assistant_request_latency_seconds` |
+| JSON 检索命中率 | `shopping_assistant_retrieval_hit_ratio` |
+| CPU/内存 | `kubectl top pods` |
+| 模型后端 | `/healthz` 中的 `model_provider` |
+| 检索后端 | `/healthz` 中的 `vectorstore_backend` |
 
 推荐把每次基线报告提交到 `reports/performance/` 目录，并与变更单关联。
+
+## 发布基线建议
+
+发布 `AI microservices lab baseline` 前至少记录：
+
+- 一次 `make local-demo` 健康检查结果。
+- 一次 `make check-e2e` 或等价 kind smoke test。
+- 一次 `loadgenerator` 聚合日志截图或摘要。
+- 一次 `shoppingassistantservice /metrics` 摘要。

--- a/docs/releasing/ai-microservices-lab-baseline.md
+++ b/docs/releasing/ai-microservices-lab-baseline.md
@@ -1,0 +1,54 @@
+# Release Notes: AI microservices lab baseline
+
+Suggested tag: `ai-microservices-lab-baseline`
+
+## Headline
+
+AI microservices lab baseline: multi-language cloud-native services with Kubernetes deployment paths and switchable Gemini/Ollama shopping assistant.
+
+## Highlights
+
+- Repositions the repo as `however-microservices-lab`, a cloud-native microservices and AI integration lab derived from Google Online Boutique.
+- Adds `shoppingassistantservice`, a Python AI shopping assistant with Gemini/Ollama provider switching.
+- Adds JSON catalog fallback for local demos and degraded operation when AlloyDB or model backends are unavailable.
+- Adds `make local-demo` for local Redis + Ollama + JSON catalog assistant health checks.
+- Adds kind + Skaffold + Kustomize smoke path for full local Kubernetes validation.
+- Adds `ubuntu-latest` quick multi-language CI for Go, Node.js, Python and Java.
+- Cleans deprecated GitHub Actions `::set-env` usage from legacy PR/Main workflows.
+- Documents Kustomize, Helm, Terraform, CI and performance baseline differences from upstream.
+
+## Validation Checklist
+
+- `make local-demo`
+- `make check-python`
+- `make check-node`
+- `make check-java`
+- `bash tests/repo_contract_test.sh`
+- `make check-e2e` when Docker, kind, kubectl and skaffold are available
+
+## Release Body Draft
+
+````markdown
+# AI microservices lab baseline
+
+This release establishes however-microservices-lab as a cloud-native microservices + AI integration baseline rather than a simple Online Boutique rename.
+
+Key additions:
+
+- Multi-language service matrix covering Go, Python, Node.js, Java and C#.
+- AI Shopping Assistant integrated through the frontend and a standalone Python service.
+- Gemini/Ollama model provider switching.
+- JSON catalog fallback for local and CI-friendly operation.
+- Local Redis + Ollama + JSON demo via `make local-demo`.
+- Kubernetes deployment paths through raw manifests, Kustomize, Skaffold, Helm and Terraform.
+- Fast `ubuntu-latest` CI across Go, Node, Python and Java.
+- Upstream diff documentation in `docs/diff-from-upstream.md`.
+
+Recommended first checks:
+
+```bash
+make local-demo
+make check-python
+bash tests/repo_contract_test.sh
+```
+````

--- a/scripts/local-demo.sh
+++ b/scripts/local-demo.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+COMPOSE_FILE="${ROOT_DIR}/docker-compose.local-demo.yml"
+STATE_DIR="${ROOT_DIR}/.codex_tmp/local-demo"
+PID_FILE="${STATE_DIR}/shoppingassistant.pid"
+LOG_FILE="${STATE_DIR}/shoppingassistant.log"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+VENV_DIR="${LOCAL_DEMO_VENV_DIR:-${ROOT_DIR}/.venv-local-demo}"
+ASSISTANT_PORT="${ASSISTANT_PORT:-18081}"
+OLLAMA_PORT="${LOCAL_DEMO_OLLAMA_PORT:-11434}"
+REDIS_PORT="${LOCAL_DEMO_REDIS_PORT:-6379}"
+OLLAMA_MODEL="${OLLAMA_MODEL:-qwen2.5:0.5b}"
+ACTION="${1:-start}"
+
+compose() {
+  docker compose -f "${COMPOSE_FILE}" "$@"
+}
+
+wait_for_http() {
+  local url="$1"
+  local attempts="${2:-60}"
+  for _ in $(seq 1 "${attempts}"); do
+    if curl -fsS "${url}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for ${url}" >&2
+  return 1
+}
+
+wait_for_redis() {
+  local attempts="${1:-60}"
+  for _ in $(seq 1 "${attempts}"); do
+    if compose exec -T redis redis-cli ping 2>/dev/null | grep -q PONG; then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Timed out waiting for Redis on port ${REDIS_PORT}" >&2
+  return 1
+}
+
+assistant_is_running() {
+  [[ -f "${PID_FILE}" ]] && kill -0 "$(cat "${PID_FILE}")" >/dev/null 2>&1
+}
+
+start_assistant() {
+  mkdir -p "${STATE_DIR}"
+  if assistant_is_running; then
+    echo "shoppingassistantservice already running on http://127.0.0.1:${ASSISTANT_PORT}"
+    return 0
+  fi
+
+  if [[ ! -x "${VENV_DIR}/bin/python" ]]; then
+    "${PYTHON_BIN}" -m venv "${VENV_DIR}"
+  fi
+
+  "${VENV_DIR}/bin/python" -m pip install --upgrade pip
+  "${VENV_DIR}/bin/python" -m pip install -r "${ROOT_DIR}/src/shoppingassistantservice/requirements.txt"
+
+  (
+    cd "${ROOT_DIR}/src/shoppingassistantservice"
+    env \
+      MODEL_PROVIDER=ollama \
+      OLLAMA_BASE_URL="http://localhost:${OLLAMA_PORT}" \
+      OLLAMA_ALLOWED_HOSTS="localhost,127.0.0.1" \
+      OLLAMA_MODEL="${OLLAMA_MODEL}" \
+      VECTORSTORE_BACKEND=json \
+      PRODUCT_CATALOG_JSON="${ROOT_DIR}/src/shoppingassistantservice/products.local.json" \
+      ENABLE_TRACING=0 \
+      RATE_LIMIT_MAX_REQUESTS=1000 \
+      PORT="${ASSISTANT_PORT}" \
+      "${VENV_DIR}/bin/python" shoppingassistantservice.py
+  ) >"${LOG_FILE}" 2>&1 &
+  echo "$!" > "${PID_FILE}"
+}
+
+start_demo() {
+  command -v docker >/dev/null 2>&1 || {
+    echo "Docker is required for local-demo." >&2
+    exit 1
+  }
+  command -v curl >/dev/null 2>&1 || {
+    echo "curl is required for local-demo." >&2
+    exit 1
+  }
+
+  mkdir -p "${STATE_DIR}"
+  compose up -d redis ollama
+  wait_for_redis
+  wait_for_http "http://127.0.0.1:${OLLAMA_PORT}/api/tags" 90
+
+  if [[ "${LOCAL_DEMO_PULL_MODEL:-0}" == "1" ]]; then
+    compose exec -T ollama ollama pull "${OLLAMA_MODEL}"
+  fi
+
+  start_assistant
+  wait_for_http "http://127.0.0.1:${ASSISTANT_PORT}/healthz" 60
+
+  echo "Local demo is ready."
+  echo "- Redis: 127.0.0.1:${REDIS_PORT}"
+  echo "- Ollama: http://127.0.0.1:${OLLAMA_PORT}"
+  echo "- shoppingassistantservice: http://127.0.0.1:${ASSISTANT_PORT}"
+  echo "- Logs: ${LOG_FILE}"
+  echo ""
+  echo "To exercise the model path after pulling a model:"
+  echo "  LOCAL_DEMO_PULL_MODEL=1 make local-demo"
+  echo "  curl -sS -H 'Content-Type: application/json' -d '{\"message\":\"Recommend warm desk lighting\",\"image\":\"\"}' http://127.0.0.1:${ASSISTANT_PORT}/"
+}
+
+stop_demo() {
+  if assistant_is_running; then
+    kill "$(cat "${PID_FILE}")" >/dev/null 2>&1 || true
+  fi
+  rm -f "${PID_FILE}"
+  compose down
+  echo "Local demo stopped."
+}
+
+status_demo() {
+  compose ps
+  if assistant_is_running; then
+    echo "shoppingassistantservice: running on http://127.0.0.1:${ASSISTANT_PORT}"
+  else
+    echo "shoppingassistantservice: stopped"
+  fi
+}
+
+case "${ACTION}" in
+  start)
+    start_demo
+    ;;
+  stop)
+    stop_demo
+    ;;
+  status)
+    status_demo
+    ;;
+  *)
+    echo "Usage: $0 {start|stop|status}" >&2
+    exit 2
+    ;;
+esac

--- a/src/checkoutservice/main.go
+++ b/src/checkoutservice/main.go
@@ -237,7 +237,7 @@ func (cs *checkoutService) PlaceOrder(ctx context.Context, req *pb.PlaceOrderReq
 
 	prep, err := cs.prepareOrderItemsAndShippingQuoteFromCart(ctx, req.UserId, req.UserCurrency, req.Address)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, err.Error())
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	total := pb.Money{CurrencyCode: req.UserCurrency,

--- a/src/shoppingassistantservice/shoppingassistantservice.py
+++ b/src/shoppingassistantservice/shoppingassistantservice.py
@@ -137,11 +137,21 @@ def create_app(config: AppConfig | None = None) -> Flask:
                 provider=config.model_provider,
                 backend=retriever.backend,
             )
-            room_description = model_client.describe_room(req_obj.image)
+            try:
+                room_description = model_client.describe_room(req_obj.image)
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                _log_event("warning", "room_description_degraded", error=str(err))
+                room_description = (
+                    "未能读取图片或模型描述，已基于用户文字需求进入基础推荐模式。"
+                )
             vector_search_prompt = (
                 f"用户需求：{req_obj.message}。请从商品目录中检索与以下房间风格最匹配的商品：{room_description}"
             )
-            docs = retriever.similarity_search(vector_search_prompt, config.vector_top_k)
+            try:
+                docs = retriever.similarity_search(vector_search_prompt, config.vector_top_k)
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                _log_event("warning", "catalog_retrieval_degraded", error=str(err))
+                docs = []
             candidate_ids = _extract_product_ids(docs)
             relevant_docs = ", ".join([json.dumps(doc, ensure_ascii=False) for doc in docs])
             content = model_client.recommend_products(

--- a/src/shoppingassistantservice/tests/test_shoppingassistantservice_unit.py
+++ b/src/shoppingassistantservice/tests/test_shoppingassistantservice_unit.py
@@ -16,6 +16,14 @@ class _DummyResponse:
         return {"response": self._content}
 
 
+class _FailingResponse:
+    def raise_for_status(self):
+        raise RuntimeError("model backend unavailable")
+
+    def json(self):
+        return {}
+
+
 @pytest.fixture
 def json_catalog_path() -> str:
     return str(Path(__file__).resolve().parent.parent / "products.local.json")
@@ -89,6 +97,121 @@ def test_metrics_endpoint_exposes_prometheus_metrics(
     text = metrics_resp.get_data(as_text=True)
     assert "shopping_assistant_requests_total" in text
     assert "shopping_assistant_retrieval_queries_total" in text
+
+
+def test_ollama_provider_uses_configured_generate_endpoint(
+    monkeypatch: pytest.MonkeyPatch, json_catalog_path: str
+):
+    calls = []
+
+    def fake_post(url, json, timeout):
+        calls.append({"url": url, "json": json, "timeout": timeout})
+        return _DummyResponse("推荐文本 [2ZYFJ3GM2N]")
+
+    monkeypatch.setattr(appmod.requests, "post", fake_post)
+    app = appmod.create_app(_build_test_config(monkeypatch, json_catalog_path))
+    client = app.test_client()
+
+    resp = client.post("/", json={"message": "warm desk lamp", "image": ""})
+    assert resp.status_code == 200
+    assert calls
+    assert calls[0]["url"] == "http://localhost:11434/api/generate"
+    assert calls[0]["json"]["model"] == "qwen2.5:7b"
+    assert calls[0]["timeout"] == 60
+
+
+def test_gemini_provider_contract_with_fake_client(
+    monkeypatch: pytest.MonkeyPatch, json_catalog_path: str
+):
+    class _FakeGeminiClient:
+        def __init__(self, config, circuit_breaker):
+            assert config.model_provider == "gemini"
+            self._circuit_breaker = circuit_breaker
+
+        def describe_room(self, image_url: str) -> str:
+            assert image_url == ""
+            return "gemini described a warm minimalist room"
+
+        def recommend_products(
+            self, room_description: str, relevant_docs: str, customer_prompt: str
+        ) -> str:
+            assert "gemini described" in room_description
+            assert "warm minimalist" in customer_prompt
+            assert isinstance(relevant_docs, str)
+            return "Gemini 推荐 [2ZYFJ3GM2N]"
+
+    monkeypatch.setenv("MODEL_PROVIDER", "gemini")
+    monkeypatch.setenv("VECTORSTORE_BACKEND", "json")
+    monkeypatch.setenv("PRODUCT_CATALOG_JSON", json_catalog_path)
+    monkeypatch.setenv("ENABLE_TRACING", "0")
+    monkeypatch.setenv("RATE_LIMIT_MAX_REQUESTS", "120")
+    monkeypatch.setattr(appmod, "DesignModelClient", _FakeGeminiClient)
+
+    app = appmod.create_app(appmod._build_config())
+    resp = app.test_client().post(
+        "/", json={"message": "warm minimalist desk setup", "image": ""}
+    )
+
+    assert resp.status_code == 200
+    assert "Gemini 推荐" in resp.get_json()["content"]
+
+
+def test_alloydb_backend_falls_back_to_json_catalog(
+    monkeypatch: pytest.MonkeyPatch, json_catalog_path: str
+):
+    for name in (
+        "PROJECT_ID",
+        "REGION",
+        "ALLOYDB_DATABASE_NAME",
+        "ALLOYDB_TABLE_NAME",
+        "ALLOYDB_CLUSTER_NAME",
+        "ALLOYDB_INSTANCE_NAME",
+        "ALLOYDB_SECRET_NAME",
+        "ALLOYDB_PASSWORD",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("MODEL_PROVIDER", "ollama")
+    monkeypatch.setenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("OLLAMA_ALLOWED_HOSTS", "localhost,127.0.0.1")
+    monkeypatch.setenv("VECTORSTORE_BACKEND", "alloydb")
+    monkeypatch.setenv("PRODUCT_CATALOG_JSON", json_catalog_path)
+    monkeypatch.setenv("ENABLE_TRACING", "0")
+    monkeypatch.setattr(
+        appmod.requests,
+        "post",
+        lambda *args, **kwargs: _DummyResponse("推荐文本 [2ZYFJ3GM2N]"),
+    )
+
+    app = appmod.create_app(appmod._build_config())
+    health = app.test_client().get("/healthz")
+
+    assert health.status_code == 200
+    assert health.get_json()["vectorstore_backend"] == "json"
+
+
+def test_model_recommendation_failure_returns_degraded_response(
+    monkeypatch: pytest.MonkeyPatch, json_catalog_path: str
+):
+    calls = 0
+
+    def fake_post(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return _DummyResponse("warm wood and neutral textiles")
+        return _FailingResponse()
+
+    monkeypatch.setenv("MAX_RETRIES", "0")
+    monkeypatch.setattr(appmod.requests, "post", fake_post)
+    app = appmod.create_app(_build_test_config(monkeypatch, json_catalog_path))
+    client = app.test_client()
+
+    resp = client.post("/", json={"message": "warm reading corner", "image": ""})
+    body = resp.get_json()
+
+    assert resp.status_code == 200
+    assert "保护模式" in body["content"]
+    assert "[NO_MATCH]" in body["content"]
 
 
 def test_config_rejects_unknown_model_provider(

--- a/tests/repo_contract_test.sh
+++ b/tests/repo_contract_test.sh
@@ -10,6 +10,10 @@ required_files=(
   ".github/dependabot.yml"
   ".github/workflows/codeql.yml"
   ".github/workflows/repo-contract-ci.yml"
+  ".github/workflows/quick-ci.yaml"
+  "docs/diff-from-upstream.md"
+  "docs/local-demo.md"
+  "docs/kind-skaffold-kustomize.md"
   "docs/ENGINEERING_QUALITY.md"
 )
 


### PR DESCRIPTION
## Summary

- Repositions the README around the AI microservices lab baseline.
- Adds upstream-diff documentation, local Redis/Ollama/JSON demo docs and scripts, kind/Skaffold/Kustomize guidance, performance baseline notes, and baseline release notes.
- Adds quick ubuntu-latest CI and strengthens shoppingassistant fallback tests.

## Validation

- `python3 -m pytest` in `src/shoppingassistantservice`
- `python3 -m ruff check .` and `python3 -m mypy shoppingassistantservice.py config.py metrics.py resilience.py retriever.py model_client.py`
- Node `npm ci && npm test` for `currencyservice` and `paymentservice`
- `bash tests/repo_contract_test.sh`
- workflow YAML parse, docker compose config, SVG XML, selected Markdown links

## Notes

- Local Go tests were not run because this machine does not have `go` installed; quick CI installs Go through `actions/setup-go`.
- Local Java Gradle verification was interrupted after it ran unusually long without new output; quick CI runs it on GitHub with Java 21.
